### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -2,6 +2,9 @@ name: Android CI
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/JensCarlberg/TeaTimer/security/code-scanning/1](https://github.com/JensCarlberg/TeaTimer/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/android.yml` at the workflow root (recommended here since there is only one job).  
Use least privilege required for this workflow: `contents: read` is the minimal baseline and sufficient for `actions/checkout` and typical build-only CI.

Concretely:
- Edit `.github/workflows/android.yml`
- Insert after the `on:` section (before `jobs:`):
  - `permissions:`
  - `  contents: read`

No imports, methods, or external dependencies are needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
